### PR TITLE
Add a mix task to easily generate JWT tokens

### DIFF
--- a/neurow/lib/mix/tasks/generate_jwt_token.ex
+++ b/neurow/lib/mix/tasks/generate_jwt_token.ex
@@ -1,0 +1,66 @@
+defmodule Mix.Tasks.GenerateJwtToken do
+  @moduledoc """
+  This mix task generates JWT tokens that are accepted by the public and internal APIs, by using
+  authentication settings defined in the neurow configuration.
+  """
+
+  @doc """
+  ## Examples
+
+  Generate tokens for the public API:
+  ```
+  mix generate_jwt_token --api=public --issuer=test_issuer1 --topic=user:1234
+  ```
+
+  Generate tokens for the internal API:
+  ```
+  mix generate_jwt_token --api=internal --issuer=test_issuer1
+  ```
+
+  """
+
+  use Mix.Task
+
+  @requirements ["app.config"]
+
+  def run(args) do
+    {parsed_args, _args, _invalid} =
+      OptionParser.parse(args, strict: [api: :string, issuer: :string, topic: :string])
+
+    Neurow.Configuration.start_link(%{})
+
+    case {parsed_args[:api], parsed_args[:issuer], parsed_args[:topic]} do
+      {"public", issuer, topic} when is_binary(issuer) and is_binary(topic) ->
+        IO.puts(
+          Neurow.JwtAuthPlug.generate_jwt_token(
+            issuer,
+            &Neurow.Configuration.public_api_issuer_jwks/1,
+            Neurow.Configuration.public_api_audience(),
+            topic
+          )
+        )
+
+      {"public", issuer, _topic} when is_nil(issuer) ->
+        raise ArgumentError, message: "An issuer is expected"
+
+      {"public", _issuer, topic} when is_nil(topic) ->
+        raise ArgumentError, message: "A topic is expected"
+
+      {"internal", issuer, _topic} when is_binary(issuer) ->
+        IO.puts(
+          Neurow.JwtAuthPlug.generate_jwt_token(
+            issuer,
+            &Neurow.Configuration.internal_api_issuer_jwks/1,
+            Neurow.Configuration.internal_api_audience()
+          )
+        )
+
+      {"internal", issuer, _topic} when is_nil(issuer) ->
+        raise ArgumentError, message: "An issuer is expected"
+
+      {_other_api, _issuer, _topic} ->
+        raise ArgumentError,
+          message: "Invalid api '#{parsed_args[:api]}', expecting 'public' or 'internal'"
+    end
+  end
+end


### PR DESCRIPTION
By using authentication settings defined in the neurow configuration, this mix task prints JWT tokens on the standard output  that are accepted by the public and internal APIs,

### Public API
Generate tokens for the public API:
```
mix generate_jwt_token --api=public --issuer=test_issuer1 --topic=user:1234
```

Then to subscribe to the public api with curl: 
```
curl http://localhost:4000/v1/subscribe -H "Authorization: Bearer <token>"
```

### Internal API
Generate tokens for the internal API:
```
mix generate_jwt_token --api=internal --issuer=test_issuer1
```

Then, to publish messages on the internal api with curl:
```
curl http://localhost:3000/v1/publish -H "Content-Type: application/json" -X POST -d '{"message": "Hello world!" , "topic": "user:1234"}' -H "Authorization: Bearer  <token>"
```