### PR TITLE
Support preflight requests on the public API, so frontend can subscribe from other domains

### DIFF
--- a/neurow/config/runtime.exs
+++ b/neurow/config/runtime.exs
@@ -4,21 +4,21 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   level: String.to_atom(System.get_env("LOG_LEVEL") || "info")
 
-config :neurow, public_api_port: String.to_integer(System.get_env("PUBLIC_API_PORT") || "4000")
-
+# Public API configuration
 config :neurow,
+  public_api_port: String.to_integer(System.get_env("PUBLIC_API_PORT") || "4000"),
   public_api_jwt_max_lifetime:
-    String.to_integer(System.get_env("PUBLIC_API_JWT_MAX_LIFETIME") || "120")
+    String.to_integer(System.get_env("PUBLIC_API_JWT_MAX_LIFETIME") || "120"),
+  public_api_allowed_origins: [~r/^https:\/\/.*\.doctolib\.(fr|it|de)(:3000)?$/],
+  public_api_preflight_max_age: String.to_integer(System.get_env("PREFLIGHT_MAX_AGE") || "86400"),
+  sse_timeout: String.to_integer(System.get_env("SSE_TIMEOUT") || "900000"),
+  sse_keepalive: String.to_integer(System.get_env("SSE_KEEPALIVE") || "600000")
 
+# Internal API configuration
 config :neurow,
-  internal_api_port: String.to_integer(System.get_env("INTERNAL_API_PORT") || "3000")
-
-config :neurow,
+  internal_api_port: String.to_integer(System.get_env("INTERNAL_API_PORT") || "3000"),
   internal_api_jwt_max_lifetime:
     String.to_integer(System.get_env("INTERNAL_API_JWT_MAX_LIFETIME") || "1500")
-
-config :neurow, sse_timeout: String.to_integer(System.get_env("SSE_TIMEOUT") || "900000")
-config :neurow, sse_keepalive: String.to_integer(System.get_env("SSE_KEEPALIVE") || "600000")
 
 config :neurow, ssl_keyfile: System.get_env("SSL_KEYFILE")
 config :neurow, ssl_certfile: System.get_env("SSL_CERTFILE")

--- a/neurow/lib/neurow/internal_api/endpoint.ex
+++ b/neurow/lib/neurow/internal_api/endpoint.ex
@@ -14,6 +14,7 @@ defmodule Neurow.InternalApi.Endpoint do
     verbose_authentication_errors:
       &Neurow.Configuration.internal_api_verbose_authentication_errors/0,
     max_lifetime: &Neurow.Configuration.internal_api_jwt_max_lifetime/0,
+    send_forbidden: &Neurow.InternalApi.Endpoint.send_forbidden/3,
     inc_error_callback: &Stats.inc_jwt_errors_internal/0,
     exclude_path_prefixes: ["/ping", "/nodes", "/cluster_size_above", "/history"]
   )
@@ -100,7 +101,7 @@ defmodule Neurow.InternalApi.Endpoint do
         )
 
       {:error, reason} ->
-        conn |> send_bad_request(:invalid_payload, reason)
+        conn |> send_error(:invalid_payload, reason)
     end
   end
 
@@ -132,9 +133,13 @@ defmodule Neurow.InternalApi.Endpoint do
     end
   end
 
-  defp send_bad_request(conn, error_code, error_message) do
-    {:ok, response} =
-      Jason.encode(%{
+  def send_forbidden(conn, error_code, error_message) do
+    send_error(conn, error_code, error_message, :forbidden)
+  end
+
+  defp send_error(conn, error_code, error_message, status \\ :bad_request) do
+    response =
+      Jason.encode!(%{
         errors: [
           %{error_code: error_code, error_message: error_message}
         ]
@@ -142,6 +147,6 @@ defmodule Neurow.InternalApi.Endpoint do
 
     conn
     |> put_resp_header("content-type", "application/json")
-    |> resp(:bad_request, response)
+    |> resp(status, response)
   end
 end

--- a/neurow/lib/neurow/public_api.ex
+++ b/neurow/lib/neurow/public_api.ex
@@ -5,7 +5,7 @@ defmodule Neurow.PublicApi do
 
   plug(:monitor_sse)
 
-  plug(:cors_preflight_request)
+  plug(:preflight_request)
 
   plug(Neurow.JwtAuthPlug,
     jwk_provider: &Neurow.Configuration.public_api_issuer_jwks/1,
@@ -100,7 +100,7 @@ defmodule Neurow.PublicApi do
     conn
   end
 
-  def cors_preflight_request(conn, _options) do
+  def preflight_request(conn, _options) do
     case conn.method do
       "OPTIONS" ->
         with(
@@ -114,7 +114,7 @@ defmodule Neurow.PublicApi do
             |> put_resp_header("access-control-allow-origin", origin)
             |> put_resp_header(
               "access-control-max-age",
-              preflight_request_max_page()
+              preflight_request_max_age()
             )
             |> resp(:no_content, "")
             |> halt()
@@ -228,7 +228,7 @@ defmodule Neurow.PublicApi do
     conn
   end
 
-  defp preflight_request_max_page(),
+  defp preflight_request_max_age(),
     do: Integer.to_string(Application.fetch_env!(:neurow, :public_api_preflight_max_age))
 
   defp origin_allowed?(origin) do

--- a/neurow/lib/sse_monitor.ex
+++ b/neurow/lib/sse_monitor.ex
@@ -21,6 +21,6 @@ defmodule SSEMonitor do
 
   def terminate(reason, _) do
     Stats.dec_connections()
-    Logger.debug("SSE connection terminated: #{reason}")
+    Logger.debug("SSE connection terminated: #{inspect(reason)}")
   end
 end

--- a/neurow/test/neurow/public_api_integration_test.exs
+++ b/neurow/test/neurow/public_api_integration_test.exs
@@ -212,6 +212,10 @@ defmodule Neurow.PublicApiIntegrationTest do
 
       assert {"access-control-allow-methods", "GET"} in response.resp_headers,
              "access-control-allow-methods response header"
+
+      assert {"access-control-max-age",
+              Integer.to_string(Application.fetch_env!(:neurow, :public_api_preflight_max_age))} in response.resp_headers,
+             "access-control-max-age response header"
     end
   end
 end


### PR DESCRIPTION
- Rework JwAuthPlug to delegate the generation of a forbidden error to plugs that use it,
- If an Authentication error occurs on the public API, return the content of the error as a SSE event to comply to the EventStream protocol,
- Support preflight requests on the public api for a restricted list of domains only, so it can be used by an actual JavaScript applications in a cross-domain deployment,
- Fix some typos.
