### PR TITLE
Fix Neurow in Docker

### DIFF
--- a/neurow/lib/neurow/application.ex
+++ b/neurow/lib/neurow/application.ex
@@ -1,6 +1,8 @@
 defmodule Neurow.Application do
   @moduledoc false
 
+  @mix_env Mix.env()
+
   require Logger
 
   use Application
@@ -35,7 +37,7 @@ defmodule Neurow.Application do
         history_min_duration: history_min_duration,
         cluster_topologies: cluster_topologies
       }) do
-    Logger.warning("Current host #{node()}, environment: #{Mix.env()}")
+    Logger.warning("Current host #{node()}, environment: #{@mix_env}")
     Logger.warning("Starting internal API on port #{internal_api_port}")
 
     base_public_api_http_config = [


### PR DESCRIPTION
Set Mix.env in a module variable, so it is computed at build time and not at run time