### PR TITLE
Stop SSE connections when the JWT token expires

### DIFF
--- a/neurow/integration_test/sse_livecycle_test.exs
+++ b/neurow/integration_test/sse_livecycle_test.exs
@@ -31,7 +31,7 @@ defmodule Neurow.IntegrationTest.SseLifecycleTest do
           {"transfer-encoding", "chunked"}
         ])
 
-        assert_receive %HTTPoison.AsyncChunk{chunk: timeout_sse_event}, 4_000
+        assert_receive %HTTPoison.AsyncChunk{chunk: timeout_sse_event}, 4_200
 
         assert "timeout" == parse_sse_event(timeout_sse_event).event
 

--- a/neurow/test/jwt_helper.exs
+++ b/neurow/test/jwt_helper.exs
@@ -40,10 +40,13 @@ defmodule JwtHelper do
     signed_jwt_token(jwt_payload, key)
   end
 
-  def compute_jwt_token_in_req_header_public_api(topic, issuer \\ "test_issuer1") do
+  def compute_jwt_token_in_req_header_public_api(topic, options \\ []) do
+    issuer = Keyword.get(options, :issuer, "test_issuer1")
+    duration_s = Keyword.get(options, :duration_s, 2 * 60 - 1)
+
     key = JOSE.JWK.from_oct("966KljJz--KyzyBnMOrFXfAkq9XMqWwPgdBV3cKTxsc")
     iat = :os.system_time(:second)
-    exp = iat + (2 * 60 - 1)
+    exp = iat + duration_s
 
     jwt_payload = %{
       "iss" => issuer,


### PR DESCRIPTION
With this PR, the SSE connection is closed when the JWT token used to authenticate actually expires. Previously, the JWT token expiration was only checked when the SSE connection is established.

Benefits:
- Improve overall security by preventing over-usage of JWT tokens,
- Allow backends that issue tokens to have their own expiration policy (which must still be lower than the global max lifetime configured in Neurow). For exemple, it allows the backend to use an `exp` that matches the duration when users are actually considered as active on the frontend.