### PR TITLE
chore: Ensure container image can be started correctly after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           docker build . -t neurow:latest
           docker run -d --name neurow_test neurow:latest
           sleep 10
+          docker ps -a
+          docker logs neurow_test
           docker exec neurow_test curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
           docker stop neurow_test
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           cd neurow && docker build . -t neurow:latest
-          docker run -d --name neurow_test neurow:latest
-          sleep 5
+          docker run -d -p 4000:4000 --name neurow_test neurow:latest
+          curl --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:4000/ping 
           docker stop neurow_test
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: cd neurow && docker build .
+      - run: |
+          cd neurow && docker build . -t neurow:latest
+          docker run -d --name neurow_test neurow:latest
+          sleep 5
+          docker stop neurow_test
+          docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,6 @@ jobs:
           cd neurow 
           docker build . -t neurow:latest
           docker run -d -p 3000:3000 --name neurow_test neurow:latest
+          sleep 10
           curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,5 @@ jobs:
           cd neurow 
           docker build . -t neurow:latest
           docker run -d -p 3000:3000 --name neurow_test neurow:latest
-          curl --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
-          docker stop neurow_test
+          curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           cd neurow 
-          docker build . -t neurow:latest
-          docker run -e JWT_CONFIG="{\"local_name\":\"neurow\",\"service_name\":\"neurow\",\"algorithm\":\"HS256\",\"clients\":{\"test\":\"secret\"}}" -d --name neurow_test neurow:latest
-          docker exec neurow_test curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
-          docker stop neurow_test
-          docker rm neurow_test
+          docker build . -t neurow:${{ github.sha }}
+          docker run -e JWT_CONFIG="{\"local_name\":\"neurow\",\"service_name\":\"neurow\",\"algorithm\":\"HS256\",\"clients\":{\"test\":\"secret\"}}" -d --name neurow_${{ github.sha }}_test neurow:${{ github.sha }}
+          docker exec neurow_${{ github.sha }}_test curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
+          docker stop neurow_${{ github.sha }}_test
+          docker rm neurow_${{ github.sha }}_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
           cd neurow 
           docker build . -t neurow:latest
           docker run -e JWT_CONFIG="{\"local_name\":\"neurow\",\"service_name\":\"neurow\",\"algorithm\":\"HS256\",\"clients\":{\"test\":\"secret\"}}" -d --name neurow_test neurow:latest
-          sleep 10
-          docker ps -a
-          docker logs neurow_test
           docker exec neurow_test curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
           docker stop neurow_test
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          cd neurow && docker build . -t neurow:latest
+          cd neurow 
+          docker build . -t neurow:latest
           docker run -d -p 4000:4000 --name neurow_test neurow:latest
           curl --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:4000/ping 
           docker stop neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       - run: |
           cd neurow 
           docker build . -t neurow:latest
-          docker run -d -p 3000:3000 --name neurow_test neurow:latest
+          docker run -d --name neurow_test neurow:latest
           sleep 10
-          curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
+          docker exec neurow_test curl -v --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
+          docker stop neurow_test
           docker rm neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - run: |
           cd neurow 
           docker build . -t neurow:latest
-          docker run -d --name neurow_test neurow:latest
+          docker run -e JWT_CONFIG="{\"local_name\":\"neurow\",\"service_name\":\"neurow\",\"algorithm\":\"HS256\",\"clients\":{\"test\":\"secret\"}}" -d --name neurow_test neurow:latest
           sleep 10
           docker ps -a
           docker logs neurow_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - run: |
           cd neurow 
           docker build . -t neurow:latest
-          docker run -d -p 4000:4000 --name neurow_test neurow:latest
-          curl --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:4000/ping 
+          docker run -d -p 3000:3000 --name neurow_test neurow:latest
+          curl --retry 5 --retry-connrefused --retry-max-time 30 --retry-delay 6 http://localhost:3000/ping 
           docker stop neurow_test
           docker rm neurow_test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea


### PR DESCRIPTION
## Changes

This PR adds an extra step on the docker build to ensure that the container is able to start correctly and that the internal API is responding on port 3000 on the ping endpoint.

Since the image is already embarking curl, probably for healthcheck reason, I run the command directly in the container context. 

It's also possible to run it directly from the CI env but this will introduce coupling on port used and I think it's can mess up since the host port would not be able to be mapped more than once.