### PR TITLE
ECS json logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ All commands provided here must be run in the `/neurow` directory
 
 - Install the latest version of Elixir by following instructions provided [here](https://elixir-lang.org/install.html),
 - Run `mix deps.get` to download the dependencies required by Neurow,
-- Run `mix run --no-halt` to start Neurow locally with the default development configuration. The public API in available on `http://localhost:4000` and the internal API on `http://localhost:3000`.
+- Run `mix run --no-halt` to start Neurow locally with the default development configuration. The public API is then available on `http://localhost:4000` and the internal API on `http://localhost:3000`.
 
-It is possible to override the default local configuration with environment variables. For example to run Neurow on custom ports: `PUBLIC_API_PORT=5000 INTERNAL_API_PORT=5000  mix run --no-halt `
+It is possible to override the default local configuration with environment variables. For example to run Neurow on custom ports: `PUBLIC_API_PORT=5000 INTERNAL_API_PORT=5000 mix run --no-halt `
 
 
 Available environment variables are:
@@ -28,6 +28,7 @@ Available environment variables are:
 | Name | Default value | Role |
 | --- | --- | --- | 
 | `LOG_LEVEL` | info | Log level |
+| `LOG_FORMAT` | TEXT | Log format, possible values: `TEXT` - space separated attributes, `ECS` - JSON format compatible with the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html) | 
 | `PUBLIC_API_PORT` | 4000 | TCP port of the public API |
 | `PUBLIC_API_JWT_MAX_LIFETIME` | 120 | Max lifetime in seconds allowed for JWT tokens issued on the public API |
 | `PUBLIC_API_CONTEXT_PATH` | "" | URL prefix for resources of the public API - Useful to mount Neurow on a existing website|
@@ -40,8 +41,7 @@ Available environment variables are:
 
 
 ### Generate JWT tokens for the local environment
-
-Both the public and internal APIs rely on JWT tokens for authentication. For now JWT tokens are signed tokens with shared secret keys. (The support of assymetric signatures will be supported later.)
+Both the public and internal APIs rely on JWT tokens for authentication. For now JWT tokens are signed tokens with shared secret keys. Assymetric signatures will be supported later.
 
 Developement issuers and their signature keys are hard coded in `config/runtimes.exs:51`. The available issuers are `test_issuer1` and `test_issuer2`. 
 
@@ -53,7 +53,6 @@ To generate a JWT token for the internal API, run:
 
 
 ### Run tests
-
 - `mix test` runs all tests (both unit and integration tests)
 - `mix test.unit` runs unit tests
 - `mix test.integration` run integration tests

--- a/neurow/config/config.exs
+++ b/neurow/config/config.exs
@@ -1,0 +1,15 @@
+# Executed at compile time
+
+import Config
+
+case Mix.env() do
+  :prod ->
+    config :logger,
+      compile_time_purge_matching: [
+        [level_lower_than: :info]
+      ]
+
+  _ ->
+    # Do nothing
+    nil
+end

--- a/neurow/config/runtime.exs
+++ b/neurow/config/runtime.exs
@@ -1,3 +1,5 @@
+# Executed at execution time
+
 import Config
 
 case System.get_env("LOG_FORMAT") do

--- a/neurow/config/runtime.exs
+++ b/neurow/config/runtime.exs
@@ -1,8 +1,21 @@
 import Config
 
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  level: String.to_atom(System.get_env("LOG_LEVEL") || "info")
+case System.get_env("LOG_FORMAT") do
+  log_format when log_format in ["TEXT", nil] ->
+    config :logger, :console,
+      metadata: [:mfa],
+      format: "$time $metadata[$level] $message\n",
+      level: String.to_atom(System.get_env("LOG_LEVEL") || "info")
+
+  "ECS" ->
+    config :logger, :console,
+      metadata: :all,
+      level: String.to_atom(System.get_env("LOG_LEVEL") || "info"),
+      format: {Neurow.EcsLogFormatter, :format}
+
+  other_format ->
+    raise "Unsupported log format: '#{other_format}'"
+end
 
 # Public API configuration
 config :neurow,

--- a/neurow/lib/neurow/application.ex
+++ b/neurow/lib/neurow/application.ex
@@ -1,6 +1,7 @@
 defmodule Neurow.Application do
   @moduledoc false
 
+  # Resolved at compile time
   @mix_env Mix.env()
 
   require Logger
@@ -37,8 +38,8 @@ defmodule Neurow.Application do
         history_min_duration: history_min_duration,
         cluster_topologies: cluster_topologies
       }) do
-    Logger.warning("Current host #{node()}, environment: #{@mix_env}")
-    Logger.warning("Starting internal API on port #{internal_api_port}")
+    Logger.info("Current host #{node()}, environment: #{@mix_env}")
+    Logger.info("Starting internal API on port #{internal_api_port}")
 
     base_public_api_http_config = [
       port: public_api_port,
@@ -48,7 +49,7 @@ defmodule Neurow.Application do
 
     {sse_http_scheme, public_api_http_config} =
       if ssl_keyfile != nil do
-        Logger.warning(
+        Logger.info(
           "Starting public API on port #{public_api_port}, with keyfile: #{ssl_keyfile}, certfile: #{ssl_certfile}"
         )
 
@@ -61,7 +62,7 @@ defmodule Neurow.Application do
 
         {:https, http_config}
       else
-        Logger.warning("Starting public API on port #{public_api_port} without SSL")
+        Logger.info("Starting public API on port #{public_api_port} without SSL")
         {:http, base_public_api_http_config}
       end
 

--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -23,7 +23,7 @@ defmodule Neurow.EcsLogFormatter do
         }
       },
       "ecs.version" => "8.11.0",
-      "message" => message,
+      "message" => inline(message),
       "category" => metadata[:category] || "app",
       "service" => %{
         name: "neurow",
@@ -38,9 +38,11 @@ defmodule Neurow.EcsLogFormatter do
 
   defp with_optional_attribute(payload, attribute, attribute_name) do
     if attribute,
-      do: Map.put(payload, attribute_name, attribute),
+      do: Map.put(payload, attribute_name, inline(attribute)),
       else: payload
   end
+
+  def inline(string), do: String.replace(string, ~r/\n/, "\\n")
 
   defp new_line(msg), do: "#{msg}\n"
 end

--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -1,0 +1,46 @@
+defmodule Neurow.EcsLogFormatter do
+  # Resolved at compile time
+  @revision System.get_env("GIT_COMMIT_SHA1") || "unknown"
+
+  # ECS Reference: https://www.elastic.co/guide/en/ecs/current/index.html
+
+  def format(level, message, timestamp, metadata) do
+    {{year, month, day}, {hour, minute, second, millisecond}} = timestamp
+    {:ok, date} = Date.new(year, month, day)
+    {:ok, time} = Time.new(hour, minute, second, millisecond * 1000)
+    {:ok, datetime} = DateTime.new(date, time)
+
+    {module, function, arity} = metadata[:mfa]
+
+    %{
+      "@timestamp" => datetime |> DateTime.to_iso8601(),
+      "log.level" => level,
+      "log.name" => "#{module}.#{function}/#{arity}",
+      "log.source" => %{
+        "file" => %{
+          name: to_string(metadata[:file]),
+          line: metadata[:line]
+        }
+      },
+      "ecs.version" => "8.11.0",
+      "message" => message,
+      "category" => metadata[:category] || "app",
+      "service" => %{
+        name: "neurow",
+        version: @revision
+      }
+    }
+    |> with_optional_attribute(metadata[:trace_id], "trace.id")
+    |> with_optional_attribute(metadata[:error_code], "error.code")
+    |> :jiffy.encode()
+    |> new_line()
+  end
+
+  defp with_optional_attribute(payload, attribute, attribute_name) do
+    if attribute,
+      do: Map.put(payload, attribute_name, attribute),
+      else: payload
+  end
+
+  defp new_line(msg), do: "#{msg}\n"
+end

--- a/neurow/lib/neurow/jwt_auth_plug.ex
+++ b/neurow/lib/neurow/jwt_auth_plug.ex
@@ -210,8 +210,17 @@ defmodule Neurow.JwtAuthPlug do
   end
 
   defp forbidden(conn, error_code, error_message, options) do
-    Logger.debug(
-      "JWT authentication error path: #{conn.request_path}, audience: #{options |> Options.audience()} error: #{error_code} - #{error_message}"
+    jwt_token =
+      case conn |> jwt_token_from_request() do
+        {:ok, jwt_token} -> jwt_token
+        _ -> nil
+      end
+
+    Logger.error(
+      "JWT authentication error: #{error_code} - #{error_message}, path: '#{conn.request_path}', audience: '#{options |> Options.audience()}', token: '#{jwt_token}'",
+      category: "security",
+      error_code: "jwt_authentication.#{error_code}",
+      trace_id: conn |> get_req_header("x-request-id") |> List.first()
     )
 
     conn =

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -165,9 +165,9 @@ defmodule Neurow.PublicApi.Endpoint do
 
     {conn, sent} = process_history(conn, last_event_id, 0, history)
 
-    Logger.debug(fn ->
+    Logger.debug(
       "Imported history for #{topic}, last_event_id: #{last_event_id}, imported size: #{sent}"
-    end)
+    )
 
     conn
   end

--- a/neurow/test/neurow/ecs_log_formatter_test.exs
+++ b/neurow/test/neurow/ecs_log_formatter_test.exs
@@ -100,4 +100,51 @@ defmodule Neurow.EcsLogFormatterTest do
              "error.code" => "invalid_last_event_id"
            }
   end
+
+  test "multiline messages are inlined" do
+    metadata = %{
+      time: 1_728_556_213_722_376,
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello \n world!", nil, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log["message"] == "Hello \\n world!"
+  end
+
+  test "multiline trace_id are inlined" do
+    metadata = %{
+      time: 1_728_556_213_722_376,
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      trace_id: "123\n456"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log["trace.id"] == "123\\n456"
+  end
+
+  test "multiline error_code are inlined" do
+    metadata = %{
+      time: 1_728_556_213_722_376,
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      error_code: "bad\nerror code"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log["error.code"] == "bad\\nerror code"
+  end
 end

--- a/neurow/test/neurow/ecs_log_formatter_test.exs
+++ b/neurow/test/neurow/ecs_log_formatter_test.exs
@@ -1,0 +1,106 @@
+defmodule Neurow.EcsLogFormatterTest do
+  use ExUnit.Case
+
+  test "generates ECS compliant logs with default metadata" do
+    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
+
+    metadata = %{
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log == %{
+             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "log.level" => "info",
+             "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
+             "log.source" => %{
+               "file" => %{
+                 "name" => "test/neurow/ecs_log_formatter_test.exs",
+                 "line" => 10
+               }
+             },
+             "ecs.version" => "8.11.0",
+             "message" => "Hello, world!",
+             "category" => "app",
+             "service" => %{
+               "name" => "neurow",
+               "version" => "unknown"
+             }
+           }
+  end
+
+  test "supports optional trace_id metadata" do
+    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
+
+    metadata = %{
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      trace_id: "1234567890"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log == %{
+             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "log.level" => "info",
+             "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
+             "log.source" => %{
+               "file" => %{
+                 "name" => "test/neurow/ecs_log_formatter_test.exs",
+                 "line" => 10
+               }
+             },
+             "ecs.version" => "8.11.0",
+             "message" => "Hello, world!",
+             "category" => "app",
+             "service" => %{
+               "name" => "neurow",
+               "version" => "unknown"
+             },
+             "trace.id" => "1234567890"
+           }
+  end
+
+  test "supports optional error_code metadata" do
+    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
+
+    metadata = %{
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      error_code: "invalid_last_event_id"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log == %{
+             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "log.level" => "info",
+             "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
+             "log.source" => %{
+               "file" => %{
+                 "name" => "test/neurow/ecs_log_formatter_test.exs",
+                 "line" => 10
+               }
+             },
+             "ecs.version" => "8.11.0",
+             "message" => "Hello, world!",
+             "category" => "app",
+             "service" => %{
+               "name" => "neurow",
+               "version" => "unknown"
+             },
+             "error.code" => "invalid_last_event_id"
+           }
+  end
+end

--- a/neurow/test/neurow/ecs_log_formatter_test.exs
+++ b/neurow/test/neurow/ecs_log_formatter_test.exs
@@ -2,20 +2,19 @@ defmodule Neurow.EcsLogFormatterTest do
   use ExUnit.Case
 
   test "generates ECS compliant logs with default metadata" do
-    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
-
     metadata = %{
+      time: 1_728_556_213_722_376,
       mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
       file: "test/neurow/ecs_log_formatter_test.exs",
       line: 10
     }
 
     json_log =
-      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
       |> :jiffy.decode([:return_maps])
 
     assert json_log == %{
-             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "@timestamp" => "2024-10-10T10:30:13.722376Z",
              "log.level" => "info",
              "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
              "log.source" => %{
@@ -35,9 +34,8 @@ defmodule Neurow.EcsLogFormatterTest do
   end
 
   test "supports optional trace_id metadata" do
-    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
-
     metadata = %{
+      time: 1_728_556_213_722_376,
       mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
       file: "test/neurow/ecs_log_formatter_test.exs",
       line: 10,
@@ -45,11 +43,11 @@ defmodule Neurow.EcsLogFormatterTest do
     }
 
     json_log =
-      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
       |> :jiffy.decode([:return_maps])
 
     assert json_log == %{
-             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "@timestamp" => "2024-10-10T10:30:13.722376Z",
              "log.level" => "info",
              "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
              "log.source" => %{
@@ -70,9 +68,8 @@ defmodule Neurow.EcsLogFormatterTest do
   end
 
   test "supports optional error_code metadata" do
-    timestamp = {{2024, 10, 23}, {12, 25, 45, 123}}
-
     metadata = %{
+      time: 1_728_556_213_722_376,
       mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
       file: "test/neurow/ecs_log_formatter_test.exs",
       line: 10,
@@ -80,11 +77,11 @@ defmodule Neurow.EcsLogFormatterTest do
     }
 
     json_log =
-      Neurow.EcsLogFormatter.format(:info, "Hello, world!", timestamp, metadata)
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
       |> :jiffy.decode([:return_maps])
 
     assert json_log == %{
-             "@timestamp" => "2024-10-23T12:25:45.123000Z",
+             "@timestamp" => "2024-10-10T10:30:13.722376Z",
              "log.level" => "info",
              "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
              "log.source" => %{


### PR DESCRIPTION
## Support of the ElasticSearch common schema

[Elastic common schema reference page](https://www.elastic.co/guide/en/ecs/current/index.html)

By setting the environment variable `LOG_FORMAT` to `ECS`, Neurow produces logs with ECS compatible JSON events. (these log events continue to be reported on the standard output)

When the ECS log format is activated, a typical log event looks like this (The log is on a single line in the standard output, but here it is formatted for readability purpose):

```json
{
   "service":{
      "version":"1be0c39c6b5dce6931976cd2fc6044850ccf2b8b", // git commit hash when running the docker image, otherwise "unknown"
      "name":"neurow"
   },
   "message":"This a log sample",
   "log.source":{
      "file":{
         "name":"lib/neurow/application.ex",
         "line":41
      }
   },
   "log.name":"Elixir.Neurow.Application.start/1",
   "log.level":"info",
   "ecs.version":"8.11.0",
   "category":"app",
   "@timestamp":"2024-10-10T12:19:48.038054Z"
   "trace.id": "optional, can be provided in metadata when calling the logger"
}
```

## Log JWT authentication errors
JWT authentication errors (either on the public API or the internal API) are reported as error logs. A Typical JWT authentication error log looks like:

```json
{
   "trace.id":"A15619DF-3DF6-4A0A-909A-F03CBFCCD16A" // Integrated to the log if the client sends a trace id in the `X-Request-Id` HTTP header.
   "service":{
      "version":"1be0c39c6b5dce6931976cd2fc6044850ccf2b8b",
      "name":"neurow"
   },
   "message":"JWT authentication error: unknown_issuer - Unknown issuer, path: '/v1/subscribe', audience: 'public_api', token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJuZXVyb3ciLCJleHAiOjE3Mjg2NDkzMjAsImlhdCI6MTcyODU2MjkyMCwiaXNzIjoic2lpbG8iLCJzdWIiOiJ0ZXN0X3RvcGljIn0.uGFtxvueTxs3RddWDbhnjo-1-AXnID3QY6iKhVX1z_Q'",
   "log.source":{
      "file":{
         "name":"lib/neurow/jwt_auth_plug.ex",
         "line":219
      }
   },
   "log.name":"Elixir.Neurow.JwtAuthPlug.forbidden/4",
   "log.level":"error",
   "error.code":"jwt_authentication.unknown_issuer",
   "ecs.version":"8.11.0",
   "category":"security",
   "@timestamp":"2024-10-10T12:22:00.724719Z"
}
```

## Other changes
- When the ECS log formatter is not used, the name of the module and function that emits logs is now included, for example: `14:26:08.615 mfa=Neurow.Application.start/1 [info] Starting internal API on port 3000`
- When Neurow is built in production mode, log statements of level lower than `INFO` are not included in the built application. This allows to log expensive messages in debug level without any impact on the production release performances, and without having to pass a function to `Logger.debug(...)`.
