### PR TITLE
Various security improvements

### DIFF
--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -37,6 +37,7 @@ defmodule Neurow.EcsLogFormatter do
     }
     |> with_optional_attribute(metadata[:trace_id], "trace.id")
     |> with_optional_attribute(metadata[:error_code], "error.code")
+    |> with_optional_attribute(metadata[:client_ip], "client.ip")
     |> :jiffy.encode()
     |> newline()
   end

--- a/neurow/lib/neurow/jwt_auth_plug.ex
+++ b/neurow/lib/neurow/jwt_auth_plug.ex
@@ -220,7 +220,8 @@ defmodule Neurow.JwtAuthPlug do
       "JWT authentication error: #{error_code} - #{error_message}, path: '#{conn.request_path}', audience: '#{options |> Options.audience()}', token: '#{jwt_token}'",
       category: "security",
       error_code: "jwt_authentication.#{error_code}",
-      trace_id: conn |> get_req_header("x-request-id") |> List.first()
+      trace_id: conn |> get_req_header("x-request-id") |> List.first(),
+      client_ip: conn |> get_req_header("x-forwarded-for") |> List.first()
     )
 
     conn =

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -46,7 +46,6 @@ defmodule Neurow.PublicApi.Endpoint do
           |> put_resp_header("access-control-allow-origin", "*")
           |> put_resp_header("cache-control", "no-cache")
           |> put_resp_header("connection", "close")
-          |> put_resp_header("x-sse-server", to_string(node()))
           |> put_resp_header("x-sse-timeout", to_string(timeout_ms))
           |> put_resp_header("x-sse-keepalive", to_string(keep_alive_ms))
 

--- a/neurow/test/neurow/ecs_log_formatter_test.exs
+++ b/neurow/test/neurow/ecs_log_formatter_test.exs
@@ -101,6 +101,40 @@ defmodule Neurow.EcsLogFormatterTest do
            }
   end
 
+  test "supports optional client_ip metadata" do
+    metadata = %{
+      time: 1_728_556_213_722_376,
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      client_ip: "127.01.02.03"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log == %{
+             "@timestamp" => "2024-10-10T10:30:13.722376Z",
+             "log.level" => "info",
+             "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
+             "log.source" => %{
+               "file" => %{
+                 "name" => "test/neurow/ecs_log_formatter_test.exs",
+                 "line" => 10
+               }
+             },
+             "ecs.version" => "8.11.0",
+             "message" => "Hello, world!",
+             "category" => "app",
+             "service" => %{
+               "name" => "neurow",
+               "version" => "unknown"
+             },
+             "client.ip" => "127.01.02.03"
+           }
+  end
+
   test "multiline messages are inlined" do
     metadata = %{
       time: 1_728_556_213_722_376,


### PR DESCRIPTION
- Trace the client ip address in ECS logs if an IP address is defined in the `x-forward-for` HTTP header,
- Remove the name of the current node (that contains the node ip address) for the HTTP response headers in the SSE connection.