### PR TITLE
Various observability fixes

### DIFF
--- a/neurow/lib/neurow/observability/http_interfaces_stats.ex
+++ b/neurow/lib/neurow/observability/http_interfaces_stats.ex
@@ -29,16 +29,40 @@ defmodule Neurow.Observability.HttpInterfacesStats do
   end
 
   def handle_event([:cowboy, :request, :stop], measurements, metadata, _config) do
-    endpoint =
-      case metadata[:req][:ref] do
-        Neurow.PublicApi.Endpoint.HTTP -> :public_api
-        Neurow.InternalApi.Endpoint.HTTP -> :internal_api
-      end
+    if monitor_path?(metadata[:req][:path]) do
+      interface =
+        case metadata[:req][:ref] do
+          Neurow.PublicApi.Endpoint.HTTP -> :public_api
+          Neurow.InternalApi.Endpoint.HTTP -> :internal_api
+        end
 
-    duration_ms = System.convert_time_unit(measurements[:duration], :native, :millisecond)
-    resp_status = metadata[:resp_status]
+      duration_ms = System.convert_time_unit(measurements[:duration], :native, :millisecond)
+      resp_status = metadata[:resp_status]
 
-    Counter.inc(name: :http_request_count, labels: [endpoint, resp_status])
-    Summary.observe([name: :http_request_duration_ms, labels: [endpoint]], duration_ms)
+      Counter.inc(name: :http_request_count, labels: [interface, trim_http_status(resp_status)])
+      Summary.observe([name: :http_request_duration_ms, labels: [interface]], duration_ms)
+    end
+  end
+
+  @unmonitored_request_paths [
+    "/ping",
+    "/favicon.ico",
+    "/metrics"
+  ]
+
+  defp monitor_path?(path) do
+    !Enum.member?(@unmonitored_request_paths, path)
+  end
+
+  defp trim_http_status(http_status) when is_binary(http_status) do
+    String.split(http_status, " ") |> Enum.at(0)
+  end
+
+  defp trim_http_status(http_status) when is_integer(http_status) do
+    Integer.to_string(http_status)
+  end
+
+  defp trim_http_status(http_status) when is_atom(http_status) do
+    Atom.to_string(http_status)
   end
 end


### PR DESCRIPTION
- `cowboy_telemetry` both provides HTTP status like "200",  "200 OK", or "403 forbidden", and they are converted to prometheus labels as `200`, `200_ok`, `403_forbidden`... In the PR, only the integer part is kept to only export labels like `200`, `403` ...
- Excludes the health check, the metric export, and the favicon from the set of HTTP resources that are monitored. The goal is to have a better understanding of the behavior of HTTP resources related to message publishing.