### PR TITLE
chore(401-when-jwt-token-is-missing): Returns 401 when jwt is missing or not parsable

### DIFF
--- a/neurow/lib/neurow/internal_api/endpoint.ex
+++ b/neurow/lib/neurow/internal_api/endpoint.ex
@@ -16,6 +16,7 @@ defmodule Neurow.InternalApi.Endpoint do
       &Neurow.Configuration.internal_api_verbose_authentication_errors/0,
     max_lifetime: &Neurow.Configuration.internal_api_jwt_max_lifetime/0,
     send_forbidden: &Neurow.InternalApi.Endpoint.send_forbidden/3,
+    send_bad_request: &Neurow.InternalApi.Endpoint.send_bad_request/3,
     inc_error_callback: &Neurow.Observability.SecurityStats.inc_jwt_errors_internal/0,
     exclude_path_prefixes: [
       "/ping",
@@ -163,6 +164,10 @@ defmodule Neurow.InternalApi.Endpoint do
 
   def send_forbidden(conn, error_code, error_message) do
     send_error(conn, error_code, error_message, :forbidden)
+  end
+
+  def send_bad_request(conn, error_code, error_message) do
+    send_error(conn, error_code, error_message, :bad_request)
   end
 
   defp send_error(conn, error_code, error_message, status \\ :bad_request) do

--- a/neurow/lib/neurow/internal_api/endpoint.ex
+++ b/neurow/lib/neurow/internal_api/endpoint.ex
@@ -16,7 +16,7 @@ defmodule Neurow.InternalApi.Endpoint do
       &Neurow.Configuration.internal_api_verbose_authentication_errors/0,
     max_lifetime: &Neurow.Configuration.internal_api_jwt_max_lifetime/0,
     send_forbidden: &Neurow.InternalApi.Endpoint.send_forbidden/3,
-    send_bad_request: &Neurow.InternalApi.Endpoint.send_bad_request/3,
+    send_unauthorized: &Neurow.InternalApi.Endpoint.send_unauthorized/3,
     inc_error_callback: &Neurow.Observability.SecurityStats.inc_jwt_errors_internal/0,
     exclude_path_prefixes: [
       "/ping",
@@ -166,8 +166,8 @@ defmodule Neurow.InternalApi.Endpoint do
     send_error(conn, error_code, error_message, :forbidden)
   end
 
-  def send_bad_request(conn, error_code, error_message) do
-    send_error(conn, error_code, error_message, :bad_request)
+  def send_unauthorized(conn, error_code, error_message) do
+    send_error(conn, error_code, error_message, :unauthorized)
   end
 
   defp send_error(conn, error_code, error_message, status \\ :bad_request) do

--- a/neurow/lib/neurow/jwt_auth_plug.ex
+++ b/neurow/lib/neurow/jwt_auth_plug.ex
@@ -11,6 +11,7 @@ defmodule Neurow.JwtAuthPlug do
       :max_lifetime,
       :inc_error_callback,
       :send_forbidden,
+      :send_bad_request,
       allowed_algorithm: "HS256",
       verbose_authentication_errors: false,
       exclude_path_prefixes: []
@@ -58,6 +59,10 @@ defmodule Neurow.JwtAuthPlug do
         ) do
           conn |> assign(:jwt_payload, payload.fields)
         else
+          {:error, :invalid_authorization_header, message} ->
+            options.inc_error_callback.()
+            conn |> bad_request(:invalid_authorization_header, message, options)
+
           {:error, code, message} ->
             options.inc_error_callback.()
             conn |> forbidden(code, message, options)
@@ -211,6 +216,18 @@ defmodule Neurow.JwtAuthPlug do
       _ ->
         {:error, :missing_aud_claim, "Missing aud claim"}
     end
+  end
+
+  defp bad_request(conn, error_code, error_message, options) do
+    Logger.error(
+      "JWT authentication error: #{error_code} - #{error_message}, path: '#{conn.request_path}'",
+      category: "security",
+      error_code: "jwt_authentication.#{error_code}",
+      trace_id: conn |> get_req_header("x-request-id") |> List.first(),
+      client_ip: conn |> get_req_header("x-forwarded-for") |> List.first()
+    )
+
+    options.send_bad_request.(conn, error_code, error_message) |> halt
   end
 
   defp forbidden(conn, error_code, error_message, options) do

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -9,6 +9,7 @@ defmodule Neurow.PublicApi.Endpoint do
     jwk_provider: &Neurow.Configuration.public_api_issuer_jwks/1,
     audience: &Neurow.Configuration.public_api_audience/0,
     send_forbidden: &Neurow.PublicApi.Endpoint.send_forbidden/3,
+    send_bad_request: &Neurow.PublicApi.Endpoint.send_bad_request/3,
     verbose_authentication_errors:
       &Neurow.Configuration.public_api_verbose_authentication_errors/0,
     max_lifetime: &Neurow.Configuration.public_api_jwt_max_lifetime/0,
@@ -84,6 +85,10 @@ defmodule Neurow.PublicApi.Endpoint do
 
   def send_forbidden(conn, error_code, error_message) do
     send_http_error(conn, 403, error_code, error_message)
+  end
+
+  def send_bad_request(conn, error_code, error_message) do
+    send_http_error(conn, 400, error_code, error_message)
   end
 
   def preflight_request(conn, _opts) do

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -9,7 +9,7 @@ defmodule Neurow.PublicApi.Endpoint do
     jwk_provider: &Neurow.Configuration.public_api_issuer_jwks/1,
     audience: &Neurow.Configuration.public_api_audience/0,
     send_forbidden: &Neurow.PublicApi.Endpoint.send_forbidden/3,
-    send_bad_request: &Neurow.PublicApi.Endpoint.send_bad_request/3,
+    send_unauthorized: &Neurow.PublicApi.Endpoint.send_unauthorized/3,
     verbose_authentication_errors:
       &Neurow.Configuration.public_api_verbose_authentication_errors/0,
     max_lifetime: &Neurow.Configuration.public_api_jwt_max_lifetime/0,
@@ -87,8 +87,8 @@ defmodule Neurow.PublicApi.Endpoint do
     send_http_error(conn, 403, error_code, error_message)
   end
 
-  def send_bad_request(conn, error_code, error_message) do
-    send_http_error(conn, 400, error_code, error_message)
+  def send_unauthorized(conn, error_code, error_message) do
+    send_http_error(conn, 401, error_code, error_message)
   end
 
   def preflight_request(conn, _opts) do

--- a/neurow/test/neurow/internal_api/endpoint_test.exs
+++ b/neurow/test/neurow/internal_api/endpoint_test.exs
@@ -21,7 +21,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   test "other routes requires a JWT sent in authorization header" do
     conn = conn(:get, "/foo")
     call = Neurow.InternalApi.Endpoint.call(conn, [])
-    assert call.status == 403
+    assert call.status == 400
 
     conn =
       conn(:get, "/foo")
@@ -34,7 +34,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   test "other routes requires a JWT sent in x-interservice-authorization header" do
     conn = conn(:get, "/foo")
     call = Neurow.InternalApi.Endpoint.call(conn, [])
-    assert call.status == 403
+    assert call.status == 400
 
     conn =
       conn(:get, "/foo")
@@ -45,7 +45,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   end
 
   describe "POST /v1/subscribe" do
-    test "returns a 403 if called without a JWT token" do
+    test "returns a 400 if called without a JWT token" do
       body =
         :jiffy.encode(%{
           message: %{event: "event_foo", payload: "foo56"},
@@ -56,10 +56,10 @@ defmodule Neurow.InternalApi.EndpointTest do
         conn(:post, "/v1/publish", body)
 
       call = Neurow.InternalApi.Endpoint.call(conn, [])
-      assert call.status == 403
+      assert call.status == 400
     end
 
-    test "returns a 403 if called with an invalid JWT token" do
+    test "returns a 400 if called with an invalid JWT token" do
       body =
         :jiffy.encode(%{
           message: %{event: "event_foo", payload: "foo56", timestamp: 123_456},
@@ -71,7 +71,7 @@ defmodule Neurow.InternalApi.EndpointTest do
         |> put_req_header("authorization", "Basic dXNlcjpwYXNzd29yZA==")
 
       call = Neurow.InternalApi.Endpoint.call(conn, [])
-      assert call.status == 403
+      assert call.status == 400
     end
 
     test "returns a 400 error if the request payload is invalid" do

--- a/neurow/test/neurow/internal_api/endpoint_test.exs
+++ b/neurow/test/neurow/internal_api/endpoint_test.exs
@@ -21,7 +21,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   test "other routes requires a JWT sent in authorization header" do
     conn = conn(:get, "/foo")
     call = Neurow.InternalApi.Endpoint.call(conn, [])
-    assert call.status == 400
+    assert call.status == 401
 
     conn =
       conn(:get, "/foo")
@@ -34,7 +34,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   test "other routes requires a JWT sent in x-interservice-authorization header" do
     conn = conn(:get, "/foo")
     call = Neurow.InternalApi.Endpoint.call(conn, [])
-    assert call.status == 400
+    assert call.status == 401
 
     conn =
       conn(:get, "/foo")
@@ -45,7 +45,7 @@ defmodule Neurow.InternalApi.EndpointTest do
   end
 
   describe "POST /v1/subscribe" do
-    test "returns a 400 if called without a JWT token" do
+    test "returns a 401 if called without a JWT token" do
       body =
         :jiffy.encode(%{
           message: %{event: "event_foo", payload: "foo56"},
@@ -56,10 +56,10 @@ defmodule Neurow.InternalApi.EndpointTest do
         conn(:post, "/v1/publish", body)
 
       call = Neurow.InternalApi.Endpoint.call(conn, [])
-      assert call.status == 400
+      assert call.status == 401
     end
 
-    test "returns a 400 if called with an invalid JWT token" do
+    test "returns a 401 if called with an invalid JWT token" do
       body =
         :jiffy.encode(%{
           message: %{event: "event_foo", payload: "foo56", timestamp: 123_456},
@@ -71,7 +71,7 @@ defmodule Neurow.InternalApi.EndpointTest do
         |> put_req_header("authorization", "Basic dXNlcjpwYXNzd29yZA==")
 
       call = Neurow.InternalApi.Endpoint.call(conn, [])
-      assert call.status == 400
+      assert call.status == 401
     end
 
     test "returns a 400 error if the request payload is invalid" do

--- a/neurow/test/neurow/jwt_auth_plug_test.exs
+++ b/neurow/test/neurow/jwt_auth_plug_test.exs
@@ -24,6 +24,9 @@ defmodule Neurow.JwtAuthPlugTest do
          send_forbidden: fn conn, error_code, error_message ->
            conn |> assign(:forbidden_error, {error_code, error_message})
          end,
+         send_bad_request: fn conn, error_code, error_message ->
+           conn |> assign(:bad_request, {error_code, error_message})
+         end,
          jwk_provider: fn issuer ->
            case issuer do
              "issuer_1" -> [@issuer_1_jwk_1, @issuer_1_jwk_2]
@@ -94,8 +97,8 @@ defmodule Neurow.JwtAuthPlugTest do
 
     assert response.halted
 
-    assert response.assigns[:forbidden_error] ==
-             {:invalid_authentication_token, "Invalid authentication token"},
+    assert response.assigns[:bad_request] ==
+             {:invalid_authorization_header, "Invalid authorization header"},
            "Error details"
   end
 
@@ -106,7 +109,7 @@ defmodule Neurow.JwtAuthPlugTest do
       assert response.halted, "Response halted"
       assert response.halted
 
-      assert response.assigns[:forbidden_error] ==
+      assert response.assigns[:bad_request] ==
                {:invalid_authorization_header, "Invalid authorization header"},
              "Error details"
     end
@@ -122,7 +125,7 @@ defmodule Neurow.JwtAuthPlugTest do
 
       assert response.halted
 
-      assert response.assigns[:forbidden_error] ==
+      assert response.assigns[:bad_request] ==
                {:invalid_authorization_header, "Invalid authorization header"},
              "Error details"
     end

--- a/neurow/test/neurow/jwt_auth_plug_test.exs
+++ b/neurow/test/neurow/jwt_auth_plug_test.exs
@@ -24,8 +24,8 @@ defmodule Neurow.JwtAuthPlugTest do
          send_forbidden: fn conn, error_code, error_message ->
            conn |> assign(:forbidden_error, {error_code, error_message})
          end,
-         send_bad_request: fn conn, error_code, error_message ->
-           conn |> assign(:bad_request, {error_code, error_message})
+         send_unauthorized: fn conn, error_code, error_message ->
+           conn |> assign(:unauthorized_error, {error_code, error_message})
          end,
          jwk_provider: fn issuer ->
            case issuer do
@@ -85,7 +85,7 @@ defmodule Neurow.JwtAuthPlugTest do
     assert response.assigns[:jwt_payload] == nil
   end
 
-  test "don not provide details about authentication errors if verbose_authentication_errors is set to false",
+  test "do not provide details about authentication errors if verbose_authentication_errors is set to false",
        %{
          default_opts: opts
        } do
@@ -97,7 +97,7 @@ defmodule Neurow.JwtAuthPlugTest do
 
     assert response.halted
 
-    assert response.assigns[:bad_request] ==
+    assert response.assigns[:unauthorized_error] ==
              {:invalid_authorization_header, "Invalid authorization header"},
            "Error details"
   end
@@ -109,7 +109,7 @@ defmodule Neurow.JwtAuthPlugTest do
       assert response.halted, "Response halted"
       assert response.halted
 
-      assert response.assigns[:bad_request] ==
+      assert response.assigns[:unauthorized_error] ==
                {:invalid_authorization_header, "Invalid authorization header"},
              "Error details"
     end
@@ -125,7 +125,7 @@ defmodule Neurow.JwtAuthPlugTest do
 
       assert response.halted
 
-      assert response.assigns[:bad_request] ==
+      assert response.assigns[:unauthorized_error] ==
                {:invalid_authorization_header, "Invalid authorization header"},
              "Error details"
     end
@@ -141,7 +141,7 @@ defmodule Neurow.JwtAuthPlugTest do
 
       assert response.halted
 
-      assert response.assigns[:forbidden_error] ==
+      assert response.assigns[:unauthorized_error] ==
                {:invalid_jwt_token, "Invalid JWT token"},
              "Error details"
     end
@@ -223,7 +223,7 @@ defmodule Neurow.JwtAuthPlugTest do
 
       assert response.halted
 
-      assert response.assigns[:forbidden_error] ==
+      assert response.assigns[:unauthorized_error] ==
                {:invalid_jwt_token, "Invalid JWT token"},
              "Error details"
     end

--- a/neurow/test/neurow/public_api/endpoint_test.exs
+++ b/neurow/test/neurow/public_api/endpoint_test.exs
@@ -12,12 +12,12 @@ defmodule Neurow.PublicApi.EndpointTest do
         conn(:get, "/v1/subscribe")
 
       call(Neurow.PublicApi.Endpoint, conn, fn ->
-        assert_receive {:send_resp_status, 403}
+        assert_receive {:send_resp_status, 400}
         assert_receive {:send_resp_body, body}
 
         json_event = parse_sse_json_event(body)
 
-        assert json_event.event == "neurow_error_403"
+        assert json_event.event == "neurow_error_400"
 
         assert json_event.data ==
                  %{
@@ -469,12 +469,12 @@ defmodule Neurow.PublicApi.EndpointTest do
         conn(:get, "/v1/subscribe")
 
       call(Neurow.PublicApi.Endpoint, conn, fn ->
-        assert_receive {:send_resp_status, 403}
+        assert_receive {:send_resp_status, 400}
         assert_receive {:send_resp_body, body}
 
         json_event = parse_sse_json_event(body)
 
-        assert json_event.event == "neurow_error_403"
+        assert json_event.event == "neurow_error_400"
 
         assert json_event.data ==
                  %{

--- a/neurow/test/neurow/public_api/endpoint_test.exs
+++ b/neurow/test/neurow/public_api/endpoint_test.exs
@@ -12,12 +12,12 @@ defmodule Neurow.PublicApi.EndpointTest do
         conn(:get, "/v1/subscribe")
 
       call(Neurow.PublicApi.Endpoint, conn, fn ->
-        assert_receive {:send_resp_status, 400}
+        assert_receive {:send_resp_status, 401}
         assert_receive {:send_resp_body, body}
 
         json_event = parse_sse_json_event(body)
 
-        assert json_event.event == "neurow_error_400"
+        assert json_event.event == "neurow_error_401"
 
         assert json_event.data ==
                  %{
@@ -37,12 +37,12 @@ defmodule Neurow.PublicApi.EndpointTest do
         |> put_req_header("authorization", "Bearer bad_token")
 
       call(Neurow.PublicApi.Endpoint, conn, fn ->
-        assert_receive {:send_resp_status, 403}
+        assert_receive {:send_resp_status, 401}
         assert_receive {:send_resp_body, body}
 
         json_event = parse_sse_json_event(body)
 
-        assert json_event.event == "neurow_error_403"
+        assert json_event.event == "neurow_error_401"
 
         assert json_event.data == %{
                  "errors" => [
@@ -464,17 +464,17 @@ defmodule Neurow.PublicApi.EndpointTest do
       :ok
     end
 
-    test "the authentication logic is applyed to urls prefixed by the context path" do
+    test "the authentication logic is applied to urls prefixed by the context path" do
       conn =
         conn(:get, "/v1/subscribe")
 
       call(Neurow.PublicApi.Endpoint, conn, fn ->
-        assert_receive {:send_resp_status, 400}
+        assert_receive {:send_resp_status, 401}
         assert_receive {:send_resp_body, body}
 
         json_event = parse_sse_json_event(body)
 
-        assert json_event.event == "neurow_error_400"
+        assert json_event.event == "neurow_error_401"
 
         assert json_event.data ==
                  %{


### PR DESCRIPTION
## Context 🧐

This PR change the behavior when JWT is not present or not parsable as a JWT token, other error later in the chain, when you have a JWT in hand are not modified.

## Changes ⛏️

Returns a 400 when the request does not contains a valid JWT token (valid: present & at least parsable)