### PR TITLE
fix(fix-missing-auth-header-logs-in-ecs-format): Add auth header to ECS logs metadata

### DIFF
--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -38,6 +38,7 @@ defmodule Neurow.EcsLogFormatter do
     |> with_optional_attribute(metadata[:trace_id], "trace.id")
     |> with_optional_attribute(metadata[:error_code], "error.code")
     |> with_optional_attribute(metadata[:client_ip], "client.ip")
+    |> with_optional_attribute(metadata[:authorization_header], "http.request.authorization")
     |> :jiffy.encode()
     |> newline()
   end


### PR DESCRIPTION
## Context 

This PR fixes a missing line not exporting the auth header to the ECS format correctly.

## Changes

Added code so that this metadata is added when logging via ECS format