### PR TITLE
chore(add-user-agent-in-logs): Add User-Agent header to ECS logs

### DIFF
--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -39,6 +39,7 @@ defmodule Neurow.EcsLogFormatter do
     |> with_optional_attribute(metadata[:error_code], "error.code")
     |> with_optional_attribute(metadata[:client_ip], "client.ip")
     |> with_optional_attribute(metadata[:authorization_header], "http.request.authorization")
+    |> with_optional_attribute(metadata[:user_agent_header], "user_agent.original")
     |> :jiffy.encode()
     |> newline()
   end

--- a/neurow/lib/neurow/jwt_auth_plug.ex
+++ b/neurow/lib/neurow/jwt_auth_plug.ex
@@ -225,6 +225,7 @@ defmodule Neurow.JwtAuthPlug do
       category: "security",
       error_code: "jwt_authentication.#{error_code}",
       authorization_header: conn |> get_req_header("authorization") |> List.first(),
+      user_agent_header: conn |> get_req_header("user-agent") |> List.first(),
       trace_id: conn |> get_req_header("x-request-id") |> List.first(),
       client_ip: conn |> get_req_header("x-forwarded-for") |> List.first()
     )

--- a/neurow/test/neurow/ecs_log_formatter_test.exs
+++ b/neurow/test/neurow/ecs_log_formatter_test.exs
@@ -101,6 +101,40 @@ defmodule Neurow.EcsLogFormatterTest do
            }
   end
 
+  test "supports optional user_agent_header metadata" do
+    metadata = %{
+      time: 1_728_556_213_722_376,
+      mfa: {Neurow.EcsLogFormatterTest, :fake_function, 4},
+      file: "test/neurow/ecs_log_formatter_test.exs",
+      line: 10,
+      user_agent_header: "Mozilla/5.0"
+    }
+
+    json_log =
+      Neurow.EcsLogFormatter.format(:info, "Hello, world!", nil, metadata)
+      |> :jiffy.decode([:return_maps])
+
+    assert json_log == %{
+             "@timestamp" => "2024-10-10T10:30:13.722376Z",
+             "log.level" => "info",
+             "log.name" => "Elixir.Neurow.EcsLogFormatterTest.fake_function/4",
+             "log.source" => %{
+               "file" => %{
+                 "name" => "test/neurow/ecs_log_formatter_test.exs",
+                 "line" => 10
+               }
+             },
+             "ecs.version" => "8.11.0",
+             "message" => "Hello, world!",
+             "category" => "app",
+             "service" => %{
+               "name" => "neurow",
+               "version" => "unknown"
+             },
+             "user_agent.original" => "Mozilla/5.0"
+           }
+  end
+
   test "supports optional client_ip metadata" do
     metadata = %{
       time: 1_728_556_213_722_376,


### PR DESCRIPTION
Adds new header to ECS logs.

Key has been chosen from this [documentation](https://www.elastic.co/guide/en/ecs/current/ecs-user_agent.html)