### PR TITLE
add-no-store-instruction-header: Add no store instruction for cache header

### DIFF
--- a/neurow/integration_test/message_brokering_test.exs
+++ b/neurow/integration_test/message_brokering_test.exs
@@ -34,7 +34,7 @@ defmodule Neurow.IntegrationTest.MessageBrokeringTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-store"},
+            {"cache-control", "no-cache, no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -91,7 +91,7 @@ defmodule Neurow.IntegrationTest.MessageBrokeringTest do
 
                 assert_headers(headers, [
                   {"access-control-allow-origin", "*"},
-                  {"cache-control", "no-store"},
+                  {"cache-control", "no-cache, no-store"},
                   {"connection", "close"},
                   {"content-type", "text/event-stream"},
                   {"transfer-encoding", "chunked"}

--- a/neurow/integration_test/message_brokering_test.exs
+++ b/neurow/integration_test/message_brokering_test.exs
@@ -34,7 +34,7 @@ defmodule Neurow.IntegrationTest.MessageBrokeringTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-cache"},
+            {"cache-control", "no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -91,7 +91,7 @@ defmodule Neurow.IntegrationTest.MessageBrokeringTest do
 
                 assert_headers(headers, [
                   {"access-control-allow-origin", "*"},
-                  {"cache-control", "no-cache"},
+                  {"cache-control", "no-store"},
                   {"connection", "close"},
                   {"content-type", "text/event-stream"},
                   {"transfer-encoding", "chunked"}

--- a/neurow/integration_test/message_history_test.exs
+++ b/neurow/integration_test/message_history_test.exs
@@ -46,7 +46,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
         assert_headers(headers, [
           {"access-control-allow-origin", "*"},
-          {"cache-control", "no-store"},
+          {"cache-control", "no-cache, no-store"},
           {"connection", "close"},
           {"content-type", "text/event-stream"},
           {"transfer-encoding", "chunked"}
@@ -70,7 +70,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-store"},
+            {"cache-control", "no-cache, no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
           ])
@@ -112,7 +112,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-store"},
+            {"cache-control", "no-cache, no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -139,7 +139,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-store"},
+            {"cache-control", "no-cache, no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -171,7 +171,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-store"},
+            {"cache-control", "no-cache, no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}

--- a/neurow/integration_test/message_history_test.exs
+++ b/neurow/integration_test/message_history_test.exs
@@ -46,7 +46,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
         assert_headers(headers, [
           {"access-control-allow-origin", "*"},
-          {"cache-control", "no-cache"},
+          {"cache-control", "no-store"},
           {"connection", "close"},
           {"content-type", "text/event-stream"},
           {"transfer-encoding", "chunked"}
@@ -70,7 +70,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-cache"},
+            {"cache-control", "no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
           ])
@@ -112,7 +112,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-cache"},
+            {"cache-control", "no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -139,7 +139,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-cache"},
+            {"cache-control", "no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}
@@ -171,7 +171,7 @@ defmodule Neurow.IntegrationTest.MessageHistoryTest do
 
           assert_headers(headers, [
             {"access-control-allow-origin", "*"},
-            {"cache-control", "no-cache"},
+            {"cache-control", "no-store"},
             {"connection", "close"},
             {"content-type", "text/event-stream"},
             {"transfer-encoding", "chunked"}

--- a/neurow/integration_test/sse_livecycle_test.exs
+++ b/neurow/integration_test/sse_livecycle_test.exs
@@ -25,7 +25,7 @@ defmodule Neurow.IntegrationTest.SseLifecycleTest do
 
         assert_headers(headers, [
           {"access-control-allow-origin", "*"},
-          {"cache-control", "no-store"},
+          {"cache-control", "no-cache, no-store"},
           {"connection", "close"},
           {"content-type", "text/event-stream"},
           {"transfer-encoding", "chunked"}
@@ -59,7 +59,7 @@ defmodule Neurow.IntegrationTest.SseLifecycleTest do
             headers,
             [
               {"access-control-allow-origin", "*"},
-              {"cache-control", "no-store"},
+              {"cache-control", "no-cache, no-store"},
               {"connection", "close"},
               {"content-type", "text/event-stream"},
               {"transfer-encoding", "chunked"},

--- a/neurow/integration_test/sse_livecycle_test.exs
+++ b/neurow/integration_test/sse_livecycle_test.exs
@@ -25,7 +25,7 @@ defmodule Neurow.IntegrationTest.SseLifecycleTest do
 
         assert_headers(headers, [
           {"access-control-allow-origin", "*"},
-          {"cache-control", "no-cache"},
+          {"cache-control", "no-store"},
           {"connection", "close"},
           {"content-type", "text/event-stream"},
           {"transfer-encoding", "chunked"}
@@ -59,7 +59,7 @@ defmodule Neurow.IntegrationTest.SseLifecycleTest do
             headers,
             [
               {"access-control-allow-origin", "*"},
-              {"cache-control", "no-cache"},
+              {"cache-control", "no-store"},
               {"connection", "close"},
               {"content-type", "text/event-stream"},
               {"transfer-encoding", "chunked"},

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -45,7 +45,7 @@ defmodule Neurow.PublicApi.Endpoint do
           conn
           |> put_resp_header("content-type", "text/event-stream")
           |> put_resp_header("access-control-allow-origin", "*")
-          |> put_resp_header("cache-control", "no-cache")
+          |> put_resp_header("cache-control", "no-store")
           |> put_resp_header("connection", "close")
           |> put_resp_header("x-sse-timeout", to_string(timeout_ms))
           |> put_resp_header("x-sse-keepalive", to_string(keep_alive_ms))

--- a/neurow/lib/neurow/public_api/endpoint.ex
+++ b/neurow/lib/neurow/public_api/endpoint.ex
@@ -45,7 +45,7 @@ defmodule Neurow.PublicApi.Endpoint do
           conn
           |> put_resp_header("content-type", "text/event-stream")
           |> put_resp_header("access-control-allow-origin", "*")
-          |> put_resp_header("cache-control", "no-store")
+          |> put_resp_header("cache-control", "no-cache, no-store")
           |> put_resp_header("connection", "close")
           |> put_resp_header("x-sse-timeout", to_string(timeout_ms))
           |> put_resp_header("x-sse-keepalive", to_string(keep_alive_ms))


### PR DESCRIPTION
## Context

We don't want any cache mechanism on requests that contains sensitive data

## Changes

Added cache header instruction no-store, see related [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) documentation