### PR TITLE
feat(EN-2932): Migrate github secrets to vault

### DIFF
--- a/.github/ci-secrets.yml
+++ b/.github/ci-secrets.yml
@@ -1,0 +1,6 @@
+secrets:
+  common:
+  - path: terraform/github/actions/neurow/common
+    version: 0
+  - path: common/github/actions/neurow/to_be_classified
+    version: 1


### PR DESCRIPTION
## Transition to Secure GitHub Actions Workflows (STEP-18 Compliance)

As part of our security enhancements, we have done the legwork to migrate approximately 100 of our 420 repositories left to no longer store secrets on GitHub servers, complying with [STEP-18](https://doctolib.atlassian.net/wiki/spaces/SEC/pages/1337655664/STEP+18+-+Github+Actions+Secrets+Security). We need your help to finalize this transition.
This change is required by Platform Security for all repositories that use GitHub Actions workflows.

### Why This Change?
- To eliminate the storage of sensitive data on GitHub servers, securing our operations.
- To allow teams to manage their own secrets using [Hashicorp Vault](https://vault-shared.doctolib.tech:8200/ui) and [yak](https://github.com/doctolib/yak)

### What to Do?
- Review this PR to confirm that your workflows behave as expected with the new secrets handling method.
- Test the workflows manually if possible, especially on this PR branch.
- **Ensure to merge this PR by 15th September.** Past this date, any remaining PRs will be force merged by the Platform Security team.

### Need Help?
- For non-urgent support, [open a ticket on the AUTOP Helpdesk](https://doctolib.atlassian.net/servicedesk/customer/portal/52/group/2094/create/1467).
- For critical and urgent issues, [raise an incident](https://doctolib.atlassian.net/servicedesk/customer/portal/69/group/2126/create/3691).

### Next Steps
- Post-merger, be vigilant for any potential failures and address them promptly to maintain smooth operations.