### PR TITLE
feat(EN-2932): Migrate github secrets to vault

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -13,14 +13,19 @@ jobs:
   docker_push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Load Secrets
+        uses: doctolib/actions/load-secrets@main
+        with:
+          prefix_secrets: true
+
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v 4.0.1
         with:
-          role-to-assume: ${{ secrets.iam_role }}
+          role-to-assume: ${{ env.VAULT_SECRET_IAM_ROLE }}
           role-session-name: docker_build_public
           aws-region: us-east-1
-
-      - uses: actions/checkout@v4
 
       - run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/doctolib


### PR DESCRIPTION
## Transition to Secure GitHub Actions Workflows (STEP-18 Compliance)

As part of our security enhancements, we have done the legwork to migrate approximately 100 of our 420 repositories left to no longer store secrets on GitHub servers, complying with [STEP-18](https://doctolib.atlassian.net/wiki/spaces/SEC/pages/1337655664/STEP+18+-+Github+Actions+Secrets+Security). We need your help to finalize this transition.
This change is required by Platform Security for all repositories that use GitHub Actions workflows.

### Why This Change?
- To eliminate the storage of sensitive data on GitHub servers, securing our operations.

### What to Do?
- Review this PR to confirm that your workflows behave as expected with the new secrets handling method.
- Test the workflows manually if possible, especially on this PR branch.
- **Ensure to merge this PR by 15th September.** Past this date, any remaining PRs will be force merged by the Platform Security team.

### Need Help?
- For non-urgent support, [open a ticket on the AUTOP Helpdesk](https://doctolib.atlassian.net/servicedesk/customer/portal/52/group/2094/create/1467).
- For critical and urgent issues, [raise an incident](https://doctolib.atlassian.net/servicedesk/customer/portal/69/group/2126/create/3691).

### Next Steps
- Post-merger, be vigilant for any potential failures and address them promptly to maintain smooth operations.