### PR TITLE
revert(EN-2932): allow neurow to use GHA secrets

### DIFF
--- a/.github/ci-secrets.yml
+++ b/.github/ci-secrets.yml
@@ -1,6 +1,0 @@
-secrets:
-  common:
-  - path: terraform/github/actions/neurow/common
-    version: 0
-  - path: common/github/actions/neurow/to_be_classified
-    version: 1

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -13,19 +13,14 @@ jobs:
   docker_push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Load Secrets
-        uses: doctolib/actions/load-secrets@main
-        with:
-          prefix_secrets: true
-
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v 4.0.1
         with:
-          role-to-assume: ${{ env.VAULT_SECRET_IAM_ROLE }}
+          role-to-assume: ${{ secrets.iam_role }}
           role-session-name: docker_build_public
           aws-region: us-east-1
+
+      - uses: actions/checkout@v4
 
       - run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/doctolib


### PR DESCRIPTION
As discussed with @benassipaul and @bpaquet this repo needs to use an ARN to push the Docker image but as an org we don't want to expose this ARN so it will be set up as a GHA secret.

- **Revert "feat(EN-2932): Migrate github secrets to vault (#56)"**
- **Revert "feat(EN-2932): Migrate github secrets to vault (#55)"**
