### PR TITLE
fix: handle stream closed error with reconnection

### DIFF
--- a/load_test/lib/load_test/user/sse.ex
+++ b/load_test/lib/load_test/user/sse.ex
@@ -166,6 +166,9 @@ defmodule SseUser do
       {:error, {:stream_error, {:stream_error, :internal_error, :"Stream reset by server."}}} ->
         reconnect(state, [first_message | remaining_messages], "Stream reset by server.")
 
+      {:error, {:stream_error, :closed}} ->
+        reconnect(state, [first_message | remaining_messages], "Stream closed by server")
+
       {:data, :nofin, chunk} ->
         Logger.debug(fn ->
           "#{header(state)} Received chunk (#{byte_size(chunk)} bytes): #{inspect(chunk)}"


### PR DESCRIPTION
## Summary
Adds proper error handling for `{:error, {:stream_error, :closed}}` to gracefully reconnect when the SSE server closes the stream.

## Problem
During load testing, we observed errors like:
```
09:37:30.358 [error] user_c2f88c99-7612-419c-a573-b845b1471862 / 5009 ms / 0 < 192 / 0:  Unexpected message {:error, {:stream_error, :closed}}
```

This error occurred when:
1. The SSE server timeout (default 5 minutes) was shorter than the client timeout
2. The server closed the stream after its timeout
3. The error fell through to the catch-all "Unexpected message" handler
4. The connection failed and error metrics were incremented

## Solution
Add a specific error handling clause for `{:error, {:stream_error, :closed}}` that:
- Calls the `reconnect/3` function when the stream is closed
- Respects the `SSE_AUTO_RECONNECT` configuration
- Allows seamless connection resumption with `Last-Event-ID` support
- Prevents false error metrics for expected reconnections

## Changes
- Added pattern match for `{:error, {:stream_error, :closed}}` in `wait_for_messages/2`
- Routes to existing `reconnect/3` function with appropriate reason message

## Test Plan
- With `SSE_AUTO_RECONNECT=true`, connections now gracefully reconnect on stream closure
- Error metrics (`users` with status `error`) are no longer incorrectly incremented
- Reconnection metrics properly track expected reconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)