### PR TITLE
feat(NTC-4403): Make max nb of connections configurable on public API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available environment variables are:
 | `PUBLIC_API_PORT` | 4000 | TCP port of the public API |
 | `PUBLIC_API_JWT_MAX_LIFETIME` | 120 | Max lifetime in seconds allowed for JWT tokens issued on the public API |
 | `PUBLIC_API_CONTEXT_PATH` | "" | URL prefix for resources of the public API - Useful to mount Neurow on a existing website|
+| `PUBLIC_API_MAX_CONNECTIONS` | infinity | Max number of simultaneous connections on the public API. Accepts an integer or `infinity`. |
 | `PREFLIGHT_MAX_AGE` | 86400 | Value of the `access-control-max-age` headers on CROS preflight responses on the public API |
 | `SSE_TIMEOUT` | 900000 | SSE deconnection delay in ms, after the last received message
 | `SSE_KEEPALIVE` | 600000 | Neurow periodically send `ping` events on SSE connections to prevent connections from being closed by network devices. This variable defines the delay between two ping events in milliseconds. |

--- a/neurow/config/runtime.exs
+++ b/neurow/config/runtime.exs
@@ -31,7 +31,13 @@ config :neurow,
   sse_keepalive: String.to_integer(System.get_env("SSE_KEEPALIVE") || "600000"),
   max_header_value_length: String.to_integer(System.get_env("MAX_HEADER_VALUE_LENGTH") || "8192"),
   ssl_keyfile: System.get_env("SSL_KEYFILE"),
-  ssl_certfile: System.get_env("SSL_CERTFILE")
+  ssl_certfile: System.get_env("SSL_CERTFILE"),
+  public_api_max_connections:
+    (case System.get_env("PUBLIC_API_MAX_CONNECTIONS") do
+       nil -> :infinity
+       "infinity" -> :infinity
+       value -> String.to_integer(value)
+     end)
 
 # Internal API configuration
 config :neurow,
@@ -40,13 +46,7 @@ config :neurow,
     String.to_integer(System.get_env("INTERNAL_API_JWT_MAX_LIFETIME") || "1500")
 
 config :neurow,
-  history_min_duration: String.to_integer(System.get_env("HISTORY_MIN_DURATION") || "30"),
-  public_api_max_connections:
-    (case System.get_env("PUBLIC_API_MAX_CONNECTIONS") do
-       nil -> :infinity
-       "infinity" -> :infinity
-       value -> String.to_integer(value)
-     end)
+  history_min_duration: String.to_integer(System.get_env("HISTORY_MIN_DURATION") || "30")
 
 case config_env() do
   :prod ->

--- a/neurow/config/runtime.exs
+++ b/neurow/config/runtime.exs
@@ -40,7 +40,13 @@ config :neurow,
     String.to_integer(System.get_env("INTERNAL_API_JWT_MAX_LIFETIME") || "1500")
 
 config :neurow,
-  history_min_duration: String.to_integer(System.get_env("HISTORY_MIN_DURATION") || "30")
+  history_min_duration: String.to_integer(System.get_env("HISTORY_MIN_DURATION") || "30"),
+  public_api_max_connections:
+    (case System.get_env("PUBLIC_API_MAX_CONNECTIONS") do
+       nil -> :infinity
+       "infinity" -> :infinity
+       value -> String.to_integer(value)
+     end)
 
 case config_env() do
   :prod ->

--- a/neurow/lib/neurow/application.ex
+++ b/neurow/lib/neurow/application.ex
@@ -17,6 +17,7 @@ defmodule Neurow.Application do
     {:ok, ssl_certfile} = Application.fetch_env(:neurow, :ssl_certfile)
     {:ok, history_min_duration} = Application.fetch_env(:neurow, :history_min_duration)
     {:ok, max_header_value_length} = Application.fetch_env(:neurow, :max_header_value_length)
+    {:ok, public_api_max_connections} = Application.fetch_env(:neurow, :public_api_max_connections)
 
     cluster_topologies =
       Application.get_env(:neurow, :cluster_topologies, cluster_topologies_from_env_variables())
@@ -28,6 +29,7 @@ defmodule Neurow.Application do
       ssl_certfile: ssl_certfile,
       max_header_value_length: max_header_value_length,
       history_min_duration: history_min_duration,
+      public_api_max_connections: public_api_max_connections,
       cluster_topologies: cluster_topologies
     })
   end
@@ -39,6 +41,7 @@ defmodule Neurow.Application do
         ssl_certfile: ssl_certfile,
         max_header_value_length: max_header_value_length,
         history_min_duration: history_min_duration,
+        public_api_max_connections: public_api_max_connections,
         cluster_topologies: cluster_topologies
       }) do
     Logger.info("Current host #{node()}, environment: #{@mix_env}")
@@ -50,7 +53,7 @@ defmodule Neurow.Application do
         max_header_value_length: max_header_value_length,
         idle_timeout: :infinity
       ],
-      transport_options: [max_connections: :infinity]
+      transport_options: [max_connections: public_api_max_connections]
     ]
 
     {sse_http_scheme, public_api_http_config} =

--- a/neurow/lib/neurow/application.ex
+++ b/neurow/lib/neurow/application.ex
@@ -17,7 +17,9 @@ defmodule Neurow.Application do
     {:ok, ssl_certfile} = Application.fetch_env(:neurow, :ssl_certfile)
     {:ok, history_min_duration} = Application.fetch_env(:neurow, :history_min_duration)
     {:ok, max_header_value_length} = Application.fetch_env(:neurow, :max_header_value_length)
-    {:ok, public_api_max_connections} = Application.fetch_env(:neurow, :public_api_max_connections)
+
+    {:ok, public_api_max_connections} =
+      Application.fetch_env(:neurow, :public_api_max_connections)
 
     cluster_topologies =
       Application.get_env(:neurow, :cluster_topologies, cluster_topologies_from_env_variables())


### PR DESCRIPTION
Add a new environment variable `PUBLIC_API_MAX_CONNECTIONS` that enables to limit the max nb of connections on the public API endpoint.