### PR TITLE
feat(NTC-4641): handle cowboy exception and early_error telemetry events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ This git repository contains:
 
 Both are independent Elixir mix applications.
 
+## Prerequisites
+
+The required Elixir and Erlang versions are declared in `mise.toml`. You can install them manually or via [mise](https://mise.jdx.dev/):
+
+1. [Install mise](https://mise.jdx.dev/getting-started.html)
+2. From the repo root, run:
+   ```sh
+   mise install
+   ```
+
 ## Neurow
 
 All commands provided here must be run in the `/neurow` directory

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "28.4.1"
+elixir = "1.18.4-otp-28"

--- a/neurow/lib/neurow/ecs_log_formatter.ex
+++ b/neurow/lib/neurow/ecs_log_formatter.ex
@@ -15,12 +15,16 @@ defmodule Neurow.EcsLogFormatter do
       |> DateTime.from_unix!(:microsecond)
       |> DateTime.to_iso8601()
 
-    {module, function, arity} = metadata[:mfa]
+    log_name =
+      case metadata[:mfa] do
+        {module, function, arity} -> "#{module}.#{function}/#{arity}"
+        _ -> "unknown"
+      end
 
     %{
       "@timestamp" => event_datetime,
       "log.level" => level,
-      "log.name" => "#{module}.#{function}/#{arity}",
+      "log.name" => log_name,
       "log.source" => %{
         "file" => %{
           name: to_string(metadata[:file]),
@@ -52,7 +56,9 @@ defmodule Neurow.EcsLogFormatter do
     Map.put(payload, key, inline(value))
   end
 
-  def inline(string), do: String.replace(string, ~r/\n/, "\\n")
+  def inline({:string, iodata}), do: inline(IO.chardata_to_string(iodata))
+  def inline(message) when is_list(message), do: inline(IO.chardata_to_string(message))
+  def inline(message) when is_binary(message), do: String.replace(message, ~r/\n/, "\\n")
 
   defp newline(msg), do: msg <> "\n"
 end

--- a/neurow/lib/neurow/observability/http_interfaces_stats.ex
+++ b/neurow/lib/neurow/observability/http_interfaces_stats.ex
@@ -14,6 +14,18 @@ defmodule Neurow.Observability.HttpInterfacesStats do
       help: "HTTP request count"
     )
 
+    Counter.declare(
+      name: :http_request_exception_count,
+      labels: [:interface, :kind],
+      help: "HTTP request exception count"
+    )
+
+    Counter.declare(
+      name: :http_request_early_error_count,
+      labels: [:status],
+      help: "HTTP request early_error count"
+    )
+
     Summary.reset(name: :http_request_duration_ms, labels: [:public_api])
     Summary.reset(name: :http_request_duration_ms, labels: [:internal_api])
 
@@ -21,7 +33,9 @@ defmodule Neurow.Observability.HttpInterfacesStats do
     :telemetry.attach_many(
       "cowboy_telemetry_handler",
       [
-        [:cowboy, :request, :stop]
+        [:cowboy, :request, :stop],
+        [:cowboy, :request, :exception],
+        [:cowboy, :request, :early_error]
       ],
       &Neurow.Observability.HttpInterfacesStats.handle_event/4,
       nil
@@ -41,6 +55,23 @@ defmodule Neurow.Observability.HttpInterfacesStats do
 
       Counter.inc(name: :http_request_count, labels: [interface, trim_http_status(resp_status)])
       Summary.observe([name: :http_request_duration_ms, labels: [interface]], duration_ms)
+    end
+  end
+
+  def handle_event([:cowboy, :request, :exception], _measurements, metadata, _config) do
+      if monitor_path?(metadata[:req][:path]) do
+        interface =
+          case metadata[:req][:ref] do
+            Neurow.PublicApi.Endpoint.HTTP -> :public_api
+            Neurow.InternalApi.Endpoint.HTTP -> :internal_api
+          end
+        Counter.inc(name: :http_request_exception_count, labels: [interface, "#{metadata[:kind]}"])
+      end
+    end
+
+  def handle_event([:cowboy, :request, :early_error], _measurements, metadata, _config) do
+    if monitor_path?(metadata[:req][:path]) do
+      Counter.inc(name: :http_request_early_error_count, labels: [trim_http_status(metadata[:resp_status])])
     end
   end
 

--- a/neurow/lib/neurow/observability/http_interfaces_stats.ex
+++ b/neurow/lib/neurow/observability/http_interfaces_stats.ex
@@ -59,19 +59,23 @@ defmodule Neurow.Observability.HttpInterfacesStats do
   end
 
   def handle_event([:cowboy, :request, :exception], _measurements, metadata, _config) do
-      if monitor_path?(metadata[:req][:path]) do
-        interface =
-          case metadata[:req][:ref] do
-            Neurow.PublicApi.Endpoint.HTTP -> :public_api
-            Neurow.InternalApi.Endpoint.HTTP -> :internal_api
-          end
-        Counter.inc(name: :http_request_exception_count, labels: [interface, "#{metadata[:kind]}"])
-      end
+    if monitor_path?(metadata[:req][:path]) do
+      interface =
+        case metadata[:req][:ref] do
+          Neurow.PublicApi.Endpoint.HTTP -> :public_api
+          Neurow.InternalApi.Endpoint.HTTP -> :internal_api
+        end
+
+      Counter.inc(name: :http_request_exception_count, labels: [interface, "#{metadata[:kind]}"])
     end
+  end
 
   def handle_event([:cowboy, :request, :early_error], _measurements, metadata, _config) do
     if monitor_path?(metadata[:req][:path]) do
-      Counter.inc(name: :http_request_early_error_count, labels: [trim_http_status(metadata[:resp_status])])
+      Counter.inc(
+        name: :http_request_early_error_count,
+        labels: [trim_http_status(metadata[:resp_status])]
+      )
     end
   end
 

--- a/neurow/lib/neurow/observability/http_interfaces_stats.ex
+++ b/neurow/lib/neurow/observability/http_interfaces_stats.ex
@@ -85,6 +85,8 @@ defmodule Neurow.Observability.HttpInterfacesStats do
     "/metrics"
   ]
 
+  def unmonitored_request_paths(), do: @unmonitored_request_paths
+
   defp monitor_path?(path) do
     !Enum.member?(@unmonitored_request_paths, path)
   end

--- a/neurow/test/neurow/observability/http_interfaces_stats_test.exs
+++ b/neurow/test/neurow/observability/http_interfaces_stats_test.exs
@@ -1,0 +1,130 @@
+defmodule Neurow.Observability.HttpInterfacesStatsTest do
+  use ExUnit.Case
+  use Prometheus.Metric
+
+  alias Neurow.Observability.HttpInterfacesStats
+
+  setup_all do
+    Counter.declare(
+      name: :http_request_exception_count,
+      labels: [:interface, :kind],
+      help: "HTTP request exception count"
+    )
+
+    Counter.declare(
+      name: :http_request_early_error_count,
+      labels: [:status],
+      help: "HTTP request early_error count"
+    )
+
+    :ok
+  end
+
+
+
+  defp counter_value(name, labels) do
+    case Counter.value(name: name, labels: labels) do
+      :undefined -> 0
+      n -> n
+    end
+  end
+
+  describe "handle_event [:cowboy, :request, :exception]" do
+    test "increments exception counter for public_api" do
+      before = counter_value(:http_request_exception_count, [:public_api, "error"])
+
+      HttpInterfacesStats.handle_event(
+        [:cowboy, :request, :exception],
+        %{},
+        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error},
+        nil
+      )
+
+      assert counter_value(:http_request_exception_count, [:public_api, "error"]) == before + 1
+    end
+
+    test "increments exception counter for internal_api" do
+      before = counter_value(:http_request_exception_count, [:internal_api, "throw"])
+
+      HttpInterfacesStats.handle_event(
+        [:cowboy, :request, :exception],
+        %{},
+        %{req: %{path: "/v1/messages", ref: Neurow.InternalApi.Endpoint.HTTP}, kind: :throw},
+        nil
+      )
+
+      assert counter_value(:http_request_exception_count, [:internal_api, "throw"]) == before + 1
+    end
+
+    test "uses the kind as a string label" do
+      before_exit = counter_value(:http_request_exception_count, [:public_api, "exit"])
+
+      HttpInterfacesStats.handle_event(
+        [:cowboy, :request, :exception],
+        %{},
+        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :exit},
+        nil
+      )
+
+      assert counter_value(:http_request_exception_count, [:public_api, "exit"]) == before_exit + 1
+    end
+
+    test "does not increment for unmonitored paths" do
+      Enum.each(["/ping", "/favicon.ico", "/metrics"], fn path ->
+        before = counter_value(:http_request_exception_count, [:public_api, "error"])
+
+        HttpInterfacesStats.handle_event(
+          [:cowboy, :request, :exception],
+          %{},
+          %{req: %{path: path, ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error},
+          nil
+        )
+
+        assert counter_value(:http_request_exception_count, [:public_api, "error"]) == before
+      end)
+    end
+  end
+
+  describe "handle_event [:cowboy, :request, :early_error]" do
+    test "increments early_error counter with binary status" do
+      before = counter_value(:http_request_early_error_count, ["400"])
+
+      HttpInterfacesStats.handle_event(
+        [:cowboy, :request, :early_error],
+        %{},
+        %{req: %{path: "/v1/subscribe"}, resp_status: "400 Bad Request"},
+        nil
+      )
+
+      assert counter_value(:http_request_early_error_count, ["400"]) == before + 1
+    end
+
+    test "increments early_error counter with integer status" do
+      before = counter_value(:http_request_early_error_count, ["400"])
+
+      HttpInterfacesStats.handle_event(
+        [:cowboy, :request, :early_error],
+        %{},
+        %{req: %{path: "/v1/subscribe"}, resp_status: 400},
+        nil
+      )
+
+      assert counter_value(:http_request_early_error_count, ["400"]) == before + 1
+    end
+
+    test "does not increment for unmonitored paths" do
+      Enum.each(["/ping", "/favicon.ico", "/metrics"], fn path ->
+        before = counter_value(:http_request_early_error_count, ["400"])
+
+        HttpInterfacesStats.handle_event(
+          [:cowboy, :request, :early_error],
+          %{},
+          %{req: %{path: path}, resp_status: "400 Bad Request"},
+          nil
+        )
+
+        assert counter_value(:http_request_early_error_count, ["400"]) == before
+      end)
+    end
+  end
+end

--- a/neurow/test/neurow/observability/http_interfaces_stats_test.exs
+++ b/neurow/test/neurow/observability/http_interfaces_stats_test.exs
@@ -5,18 +5,7 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
   alias Neurow.Observability.HttpInterfacesStats
 
   setup_all do
-    Counter.declare(
-      name: :http_request_exception_count,
-      labels: [:interface, :kind],
-      help: "HTTP request exception count"
-    )
-
-    Counter.declare(
-      name: :http_request_early_error_count,
-      labels: [:status],
-      help: "HTTP request early_error count"
-    )
-
+    HttpInterfacesStats.setup()
     :ok
   end
 
@@ -31,11 +20,10 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     test "increments exception counter for public_api" do
       before = counter_value(:http_request_exception_count, [:public_api, "error"])
 
-      HttpInterfacesStats.handle_event(
+      :telemetry.execute(
         [:cowboy, :request, :exception],
         %{},
-        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error},
-        nil
+        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error}
       )
 
       assert counter_value(:http_request_exception_count, [:public_api, "error"]) == before + 1
@@ -44,11 +32,10 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     test "increments exception counter for internal_api" do
       before = counter_value(:http_request_exception_count, [:internal_api, "throw"])
 
-      HttpInterfacesStats.handle_event(
+      :telemetry.execute(
         [:cowboy, :request, :exception],
         %{},
-        %{req: %{path: "/v1/messages", ref: Neurow.InternalApi.Endpoint.HTTP}, kind: :throw},
-        nil
+        %{req: %{path: "/v1/messages", ref: Neurow.InternalApi.Endpoint.HTTP}, kind: :throw}
       )
 
       assert counter_value(:http_request_exception_count, [:internal_api, "throw"]) == before + 1
@@ -57,11 +44,10 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     test "uses the kind as a string label" do
       before_exit = counter_value(:http_request_exception_count, [:public_api, "exit"])
 
-      HttpInterfacesStats.handle_event(
+      :telemetry.execute(
         [:cowboy, :request, :exception],
         %{},
-        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :exit},
-        nil
+        %{req: %{path: "/v1/subscribe", ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :exit}
       )
 
       assert counter_value(:http_request_exception_count, [:public_api, "exit"]) ==
@@ -69,14 +55,13 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     end
 
     test "does not increment for unmonitored paths" do
-      Enum.each(["/ping", "/favicon.ico", "/metrics"], fn path ->
+      Enum.each(HttpInterfacesStats.unmonitored_request_paths(), fn path ->
         before = counter_value(:http_request_exception_count, [:public_api, "error"])
 
-        HttpInterfacesStats.handle_event(
+        :telemetry.execute(
           [:cowboy, :request, :exception],
           %{},
-          %{req: %{path: path, ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error},
-          nil
+          %{req: %{path: path, ref: Neurow.PublicApi.Endpoint.HTTP}, kind: :error}
         )
 
         assert counter_value(:http_request_exception_count, [:public_api, "error"]) == before
@@ -88,11 +73,10 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     test "increments early_error counter with binary status" do
       before = counter_value(:http_request_early_error_count, ["400"])
 
-      HttpInterfacesStats.handle_event(
+      :telemetry.execute(
         [:cowboy, :request, :early_error],
         %{},
-        %{req: %{path: "/v1/subscribe"}, resp_status: "400 Bad Request"},
-        nil
+        %{req: %{path: "/v1/subscribe"}, resp_status: "400 Bad Request"}
       )
 
       assert counter_value(:http_request_early_error_count, ["400"]) == before + 1
@@ -101,25 +85,23 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     test "increments early_error counter with integer status" do
       before = counter_value(:http_request_early_error_count, ["400"])
 
-      HttpInterfacesStats.handle_event(
+      :telemetry.execute(
         [:cowboy, :request, :early_error],
         %{},
-        %{req: %{path: "/v1/subscribe"}, resp_status: 400},
-        nil
+        %{req: %{path: "/v1/subscribe"}, resp_status: 400}
       )
 
       assert counter_value(:http_request_early_error_count, ["400"]) == before + 1
     end
 
     test "does not increment for unmonitored paths" do
-      Enum.each(["/ping", "/favicon.ico", "/metrics"], fn path ->
+      Enum.each(HttpInterfacesStats.unmonitored_request_paths(), fn path ->
         before = counter_value(:http_request_early_error_count, ["400"])
 
-        HttpInterfacesStats.handle_event(
+        :telemetry.execute(
           [:cowboy, :request, :early_error],
           %{},
-          %{req: %{path: path}, resp_status: "400 Bad Request"},
-          nil
+          %{req: %{path: path}, resp_status: "400 Bad Request"}
         )
 
         assert counter_value(:http_request_early_error_count, ["400"]) == before

--- a/neurow/test/neurow/observability/http_interfaces_stats_test.exs
+++ b/neurow/test/neurow/observability/http_interfaces_stats_test.exs
@@ -20,8 +20,6 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
     :ok
   end
 
-
-
   defp counter_value(name, labels) do
     case Counter.value(name: name, labels: labels) do
       :undefined -> 0
@@ -66,7 +64,8 @@ defmodule Neurow.Observability.HttpInterfacesStatsTest do
         nil
       )
 
-      assert counter_value(:http_request_exception_count, [:public_api, "exit"]) == before_exit + 1
+      assert counter_value(:http_request_exception_count, [:public_api, "exit"]) ==
+               before_exit + 1
     end
 
     test "does not increment for unmonitored paths" do


### PR DESCRIPTION
## Why

Neurow was only tracking the `[:cowboy, :request, :stop]` telemetry event. Exceptions and early errors (e.g. malformed requests rejected before routing) were silently unobserved, leaving gaps in the HTTP metrics.

## How

- Registered `[:cowboy, :request, :exception]` and `[:cowboy, :request, :early_error]` in the cowboy telemetry handler.
- Added two new Prometheus counters:
  - `http_request_exception_count` (labels: `interface`, `kind`) — tracks exceptions per interface (`public_api` / `internal_api`) and exception kind (`error` / `throw` / `exit`).
  - `http_request_early_error_count` (label: `status`) — tracks early errors by HTTP status code.
- Unmonitored paths (`/ping`, `/favicon.ico`, `/metrics`) are skipped, consistent with the existing `:stop` handler.
- Fixed `EcsLogFormatter` to handle cases where `:mfa` metadata is absent and to accept multiple message formats in `inline/1`.
- Added `mise.toml` to pin Elixir and Erlang versions; updated README prerequisites accordingly.

## Changes

- `neurow/lib/neurow/observability/http_interfaces_stats.ex`: new handlers for `:exception` and `:early_error` events, two new counters
- `neurow/lib/neurow/ecs_log_formatter.ex`: guard against missing `:mfa` metadata; `inline/1` now handles iodata and lists
- `neurow/test/neurow/observability/http_interfaces_stats_test.exs`: unit tests for both new handlers (interface routing, kind label, unmonitored path skipping, binary/integer status trimming)
- `mise.toml`: pin Elixir and Erlang versions
- `README.md`: add Prerequisites section documenting manual or mise-based install

## Evidence of Testing

Unit tests cover:
- `:exception` handler increments the right counter for `public_api` and `internal_api`, with correct string kind label (`error`, `throw`, `exit`)
- `:early_error` handler trims binary and integer status codes correctly
- Both handlers skip unmonitored paths

## Review Focus

- Counter label design for `http_request_exception_count` and `http_request_early_error_count` — any naming or cardinality concerns?
- `EcsLogFormatter` fix correctness for the missing `:mfa` case

## Documentation

- README updated with Prerequisites section

---
_This pull request was created with AI assistance._