### PR TITLE
chore(ci): sync Erlang/Elixir versions in CI with mise.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@a6e26b22319003294c58386b6f25edbc7336819a # v1.18.0
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          otp-version: 26
-          elixir-version: 1.18
+          version-file: mise.toml
+          version-type: strict
       - run: cd neurow && mix format --check-formatted
       - run: cd neurow && mix deps.get
       - run: cd neurow && mix compile --warnings-as-errors
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@a6e26b22319003294c58386b6f25edbc7336819a # v1.18.0
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
-          otp-version: 26
-          elixir-version: 1.18
+          version-file: mise.toml
+          version-type: strict
       - run: cd load_test && mix format --check-formatted
       - run: cd load_test && mix deps.get
       - run: cd load_test && mix compile --warnings-as-errors


### PR DESCRIPTION
## Summary
- `erlef/setup-beam` now reads Erlang/Elixir versions via `version-file: mise.toml` (+ `version-type: strict`) instead of hardcoded `otp-version`/`elixir-version`, in both the `ci` and `ci-loadtest` jobs.
- Bumps `erlef/setup-beam` from `v1.18.0` to `v1.24.1` (latest release). `version-file`/`mise.toml` support was added in `v1.22.0` (erlef/setup-beam#415); `v1.18.0` only understood `.tool-versions` (asdf format).
- This also fixes an existing drift: `ci.yml` was still pinned to `otp-version: 26` / `elixir-version: 1.18`, while `mise.toml` already specifies `erlang = "29.0.5"` / `elixir = "1.20.4"`.

## Test plan
- [ ] Confirm CI actually runs (not blocked by org Actions policy) once the allowlist PR merges
- [ ] `ci` job: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test` all pass with Erlang 29.0.5 / Elixir 1.20.4
- [ ] `ci-loadtest` job: same checks pass for `load_test/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
